### PR TITLE
Fix errors on iterable undefined properties and add support for Schemas extending off of other schemas

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,10 +24,10 @@
         "node": true,
         "mocha": true
     },
-    "ecmaFeatures": {
-        "modules": false
-    },
     "parserOptions": {
+        "ecmaFeatures": {
+            "modules": false
+        },
         "sourceType": "module"
     }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 coverage
 examples/**/node_modules
 examples/**/*.sqlite3
+.DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -300,6 +300,11 @@
       "integrity": "sha1-VGDYA24fGhKwtbXL1Snm3B0x60s=",
       "dev": true
     },
+    "chai-spies": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/chai-spies/-/chai-spies-0.7.1.tgz",
+      "integrity": "sha1-ND2Z9RJEIS6LF+ZLk5lv97LCqbE="
+    },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -1094,7 +1099,8 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
         },
         "ansi-styles": {
           "version": "3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "molti",
-  "version": "1.2.2",
+  "version": "1.2.4",
   "lockfileVersion": 1,
   "dependencies": {
     "abbrev": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "ajv": "^5.1.5",
     "body-parser": "^1.17.2",
+    "chai-spies": "^0.7.1",
     "express": "^4.15.3",
     "knex": "^0.13.0",
     "lodash": "^4.17.4",

--- a/src/ModelSchema.js
+++ b/src/ModelSchema.js
@@ -94,10 +94,12 @@ class Schema {
     this._original = schemaDefinition;
     this._formatted = {};
     Object.keys(schemaDefinition).forEach(key => {
-      if (!schemaDefinition[key].type) throw new ReferenceError('No type specified for ' + key + ' (nested objects are not supported)');
-      if (!SchemaTypes[schemaDefinition[key].type]) throw new ReferenceError('Unknown type ' + schemaDefinition[key].type);
-
-      this._formatted[key] = this._original[key];
+      if (schemaDefinition[key]) {
+        if (!schemaDefinition[key].type) throw new ReferenceError('No type specified for ' + key + ' (nested objects are not supported)');
+        if (!SchemaTypes[schemaDefinition[key].type]) throw new ReferenceError('Unknown type ' + schemaDefinition[key].type);
+        
+        this._formatted[key] = this._original[key];
+      }
     });
   }
 

--- a/src/ModelSchema.js
+++ b/src/ModelSchema.js
@@ -97,7 +97,7 @@ class Schema {
       if (schemaDefinition[key]) {
         if (!schemaDefinition[key].type) throw new ReferenceError('No type specified for ' + key + ' (nested objects are not supported)');
         if (!SchemaTypes[schemaDefinition[key].type]) throw new ReferenceError('Unknown type ' + schemaDefinition[key].type);
-        
+
         this._formatted[key] = this._original[key];
       }
     });
@@ -152,6 +152,41 @@ class Schema {
     return { withRefs, withoutRefs };
   }
 }
+
+/**
+ * @param {Object} schemaDefinition The new schema definition including any properties to be overwritten of the baseDefinitions
+ * @param {Object[] | Object} base Either an array of a single object of base definitions that the schemaDefinition is extending
+ */
+Schema.extending = function (schemaDefinition, ...base) {
+  const builder = {};
+
+  if (base[0] instanceof Array) {
+    base = [...base[0]];
+  }
+
+  function assignToBuilder (def) {
+    if (def instanceof Schema) {
+      assignToBuilder(def._formatted);
+    } else {
+      Object.keys(def).forEach(key => {
+        if (def[key]) {
+          builder[key] = def[key];
+        }
+      });
+    }
+  }
+
+  let reversed = [];
+  for (let arg of base) {
+    reversed = [arg, ...reversed];
+  }
+
+  reversed.forEach(assignToBuilder);
+
+  assignToBuilder(schemaDefinition);
+
+  return new Schema(builder);
+};
 
 Schema.Types = Schema.SchemaTypes = Types;
 Schema._primitives = primitiveTypes;

--- a/src/ModelSchema.js
+++ b/src/ModelSchema.js
@@ -90,7 +90,16 @@ const primitiveTypes = {
   }
 };
 class Schema {
-  constructor(schemaDefinition) {
+  /**
+   * 
+   * @param {Object} schemaDefinition Description of the schema being defined
+   * @param {Object | Object[] | undefined} args Overloads the constructor to allow for redirecting to Schema.extending
+   */
+  constructor(schemaDefinition, ...args) {
+    if (args.length > 0) {
+      return Schema.extending(schemaDefinition, ...args);
+    }
+
     this._original = schemaDefinition;
     this._formatted = {};
     Object.keys(schemaDefinition).forEach(key => {

--- a/test/ModelSchema.js
+++ b/test/ModelSchema.js
@@ -69,6 +69,156 @@ describe('Schema Constructor', () => {
   });
 });
 
+describe('Schema extending', () => {
+  const baseDefinitions = [{
+    foo: {
+      type: Schema.Types.String
+    }
+  }, {
+    bar: {
+      type: Schema.Types.Number
+    }
+  }, {
+    foo: {
+      type: Schema.Types.Number
+    }
+  }];
+
+  it('should return an instance of Schema', () => {
+    const s = new Schema.extending({}, [{}]);
+
+    expect(s).to.be.instanceof(Schema);
+  });
+
+  describe('should have all the properties of the base definitions including', () => {
+    const s = new Schema.extending({
+      baz: {
+        type: Schema.Types.Boolean
+      }
+    }, baseDefinitions);
+
+    it('foo', () => {
+      expect(s._formatted.foo).not.to.be.undefined;
+    });
+
+    it('bar', () => {
+      expect(s._formatted.bar).not.to.be.undefined;
+    });
+
+    it('baz', () => {
+      expect(s._formatted.baz).not.to.be.undefined;
+    });
+  });
+
+  it('should handle plain object definitions', () => {
+    let err;
+    try {
+      new Schema.extending({
+        baz: {
+          type: Schema.Types.Boolean
+        }
+      }, baseDefinitions);
+    } catch(e) {
+      err = e;
+    }
+
+    expect(err).to.be.undefined;
+  });
+
+  it('should handle instances of Schema in the base definitions', () => {
+    let err;
+    try {
+      new Schema.extending({
+        baz: {
+          type: Schema.Types.Boolean
+        }
+      }, [...baseDefinitions, new Schema({
+        bang: {
+          type: Schema.Types.JSON
+        }
+      })]);
+    } catch(e) {
+      err = e;
+    }
+
+    expect(err).to.be.undefined;
+  });
+
+  it('should handle instance of Schema in the new schema definitions', () => {
+    let err;
+    try {
+      new Schema.extending(new Schema({
+        baz: {
+          type: Schema.Types.Boolean
+        }
+      }), baseDefinitions);
+    } catch(e) {
+      err = e;
+    }
+
+    expect(err).to.be.undefined;
+  });
+
+  it('should handle an single base definition (not array of)', () => {
+    let err;
+    try {
+      new Schema.extending({
+        baz: {
+          type: Schema.Types.Boolean
+        }
+      }, {
+        bar: {
+          type: Schema.Types.Number
+        }
+      });
+    } catch(e) {
+      err = e;
+    }
+
+    expect(err).to.be.undefined;
+  });
+
+  it('should over-write from right to left', () => {
+    const s = new Schema.extending({
+      baz: {
+        type: Schema.Types.Boolean
+      }
+    }, baseDefinitions);
+
+    expect(s._formatted.foo.type).to.equal(Schema.Types.String);
+  });
+
+  it('should handle a list of arguments instead of an array', () => {
+    const s = new Schema.extending({
+      baz: {
+        type: Schema.Types.Boolean
+      }
+    }, ...baseDefinitions);
+
+    expect(s._formatted.foo.type).to.equal(Schema.Types.String);
+  });
+
+  describe('should handle an undefined iterable property definition in any of the arguments', () => {
+    it('schemaDefinition', () => {
+      const s = new Schema.extending({
+        baz: undefined
+      }, baseDefinitions);
+  
+      expect(s._formatted.baz).to.be.undefined;
+    });
+
+    it('base', () => {
+      const s = new Schema.extending({
+        baz: undefined
+      }, [...baseDefinitions, {
+        bang: undefined
+      }]);
+
+      expect(s._formatted.bang).to.be.undefined;
+    });
+  });
+});
+
 describe('Schema Types', () => {
   it('should have string support', () => {
     let config = {

--- a/test/ModelSchema.js
+++ b/test/ModelSchema.js
@@ -1,5 +1,7 @@
 const Schema = require('../src/ModelSchema');
-const { expect } = require('chai');
+const chai = require('chai');
+chai.use(require('chai-spies'));
+const { expect } = chai;
 
 describe('Schema Constructor', () => {
   it('should instantiate', () => {
@@ -66,6 +68,14 @@ describe('Schema Constructor', () => {
     const keys = Object.keys(s._formatted);
 
     expect(keys.indexOf('id')).to.eq(-1);
+  });
+
+  it('should call Schema.extending when passed base schemas', () => {
+    const spy = chai.spy.on(Schema, 'extending');
+
+    new Schema({}, {}, {});
+
+    expect(spy).to.have.been.called();
   });
 });
 

--- a/test/ModelSchema.js
+++ b/test/ModelSchema.js
@@ -46,6 +46,27 @@ describe('Schema Constructor', () => {
 
     expect(err).not.to.be.undefined;
   });
+
+  it('should handle an explicitly undefined iterable property as a non-property', () => {
+    let err;
+    try {
+      new Schema({
+        id: undefined
+      });
+    } catch(e) {
+      err = e;
+    }
+
+    expect(err).to.be.undefined;
+  });
+
+  it('should not add keys with undefined values to the formatted dictionary', () => {
+    const s = new Schema({ id: undefined });
+
+    const keys = Object.keys(s._formatted);
+
+    expect(keys.indexOf('id')).to.eq(-1);
+  });
 });
 
 describe('Schema Types', () => {


### PR DESCRIPTION
This PR addresses issues [`#7: 
Iterable schema properties that are a value of undefined throw an error in the constructor`](https://github.com/moltijs/molti/issues/7) and [`#8: Add support for Schemas to extend other schema definitions`](https://github.com/moltijs/molti/issues/8).

The issue around undefined iterable properties was solves simply by checking that the key of the object definition is truthy.

#### Schema.extending
Provides a new constructor (and extends the original constructor) for the Schema class that allows for the new schema to extend off of other base schemas. See the linked issue for the use case.