### PR TITLE
Add deep merging of Schema property descriptors

### DIFF
--- a/src/ModelSchema.js
+++ b/src/ModelSchema.js
@@ -173,13 +173,27 @@ Schema.extending = function (schemaDefinition, ...base) {
     base = [...base[0]];
   }
 
+  function mergePropertyDescriptions (left, right) {
+    Object.keys(right).forEach(key => {
+      if (right[key] !== undefined) {
+        left[key] = right[key];
+      }
+    });
+
+    return left;
+  }
+
   function assignToBuilder (def) {
     if (def instanceof Schema) {
       assignToBuilder(def._formatted);
     } else {
       Object.keys(def).forEach(key => {
         if (def[key]) {
-          builder[key] = def[key];
+          if (builder[key]) {
+            builder[key] = mergePropertyDescriptions(builder[key], def[key]);
+          } else {
+            builder[key] = def[key];
+          }
         }
       });
     }

--- a/test/ModelSchema.js
+++ b/test/ModelSchema.js
@@ -227,6 +227,54 @@ describe('Schema extending', () => {
       expect(s._formatted.bang).to.be.undefined;
     });
   });
+
+  it('should deep merge properties', () => {
+    const s = new Schema({
+      foo: {
+        required: false
+      }
+    }, new Schema({
+      foo: {
+        type: Schema.Types.Boolean,
+        required: true
+      }
+    }));
+
+    expect(s._formatted.foo.type).to.equal(Schema.Types.Boolean);
+  });
+
+  it('should handle undefined iterables while deep merging properties', () => {
+    let err;
+    try {
+      new Schema({
+        foo: {
+          type: Schema.Types.Boolean
+        }
+      }, { foo: undefined });
+    } catch(e) {
+      err = e;
+    }
+
+    expect(err).to.be.undefined;
+  });
+
+  it('should ignore undefined iterable properties in the base schema object', () => {
+    const s = new Schema({
+      foo: {
+        required: true
+      }
+    }, {
+      foo: {
+        type: undefined
+      }
+    }, {
+      foo: {
+        type: Schema.Types.String
+      }
+    });
+
+    expect(s._formatted.foo.type).to.equal(Schema.Types.String);
+  });
 });
 
 describe('Schema Types', () => {


### PR DESCRIPTION
Addresses issue [`#10: Add support for deep merging of Schema definition objects`](https://github.com/moltijs/molti/issues/10).

``` Javascript
const s = new Schema({
  foo: {
    required: true
  }
}, {
  foo: {
    type: undefined
  }
}, {
  foo: {
    type: Schema.Types.String
  }
});
```

Now the above results in the same thing as a schema defined like so:

``` Javascript
const s = new Schema({
  foo: {
    required: true,
    type: Schema.Types.String
  }
});
```

This is useful for chaining schema definitions for endpoints that differ only by a few properties or those properties requirements.