### PR TITLE
feat(Handler, Response): Responses can be invoked and returned to the…

### DIFF
--- a/src/Generics.js
+++ b/src/Generics.js
@@ -57,83 +57,83 @@ module.exports = {
   responses: {
     get accepted () {
       return new Response(202)
-        .name('accepted')
+        .alias('accepted')
         .prop('message', 'string');
     },
     get success () {
       return new Response(200)
-        .name('success')
+        .alias('success')
         .prop('message', 'string');
     },
   
     get found () {
       return new Response(200)
-        .name('found')
+        .alias('found')
         .prop('record', 'object');
     },
   
     foundModel (modelName) {
       return new Response(200)
-        .name('found')
+        .alias('found')
         .ref('record', modelName);
     },
   
     get foundList () {
       return new Response(200)
-        .name('foundList')
+        .alias('foundList')
         .propList('records', 'object');
     },
   
     foundModelList (modelName) {
       return new Response(200)
-        .name('foundList')
+        .alias('foundList')
         .refList('records', modelName);
     },
   
     get created () {
       return new Response(201)
-        .name('created')
+        .alias('created')
         .prop('record', 'object');
     },
   
     createdModel (modelName) {
       return new Response(201)
-        .name('created')
+        .alias('created')
         .ref('record', modelName);
     },
 
     get noContent () {
       return new Response(204)
-        .name('noContent');
+        .alias('noContent');
     },
   
     get badRequest () {
       return new Response(400)
-        .name('badRequest')
+        .alias('badRequest')
         .prop('message', 'string');
     },
   
     get unauthorized () {
       return new Response(401)
-        .name('unauthorized')
+        .alias('unauthorized')
         .prop('message', 'string');
     },
   
     get forbidden () {
       return new Response(403)
-        .name('forbidden')
+        .alias('forbidden')
         .prop('message', 'string');
     },
   
     get notFound () {
       return new Response(404)
-        .name('notFound')
+        .alias('notFound')
         .prop('message', 'string');
     },
   
     get internalError () {
       return new Response(500)
-        .name('internalError')
+        .alias('internalError')
         .prop('message', 'string')
         .prop('stack', 'string');
     }

--- a/test/Generics.js
+++ b/test/Generics.js
@@ -12,7 +12,7 @@ describe('generics', () => {
     responses.forEach(type => {
       let response = Generics.responses[type];
 
-      if (is(Function)(response)) {
+      if (!is(Response)(response)) {
         response = response('');
       }
 

--- a/test/Response.js
+++ b/test/Response.js
@@ -12,7 +12,7 @@ describe('Response', () => {
   describe('description', () => {
     it('should be able to set the status, description, and name', () => {
       sampleResponse
-        .name('some name')
+        .alias('some name')
         .status(200)
         .describe('some description');
 
@@ -90,20 +90,33 @@ describe('Response', () => {
       let response = sampleResponse
         .status(200)
         .prop('prop1', 'string')
-        .prop('prop2', 'string')
-        .getResp()({
-          prop1: 'value 1',
-          prop2: 'value 2',
-          prop3: 'value 3'
-        });
-      
-      expect(response).to.be.eql({
+        .prop('prop2', 'string');
+      const data = {
+        prop1: 'value 1',
+        prop2: 'value 2',
+        prop3: 'value 3'
+      };
+      expect(response.getResp()(data)).to.be.eql({
         statusCode: 200,
+        origin: response,
         response: {
           prop1: 'value 1',
-          prop2: 'value 2'
+          prop2: 'value 2',
         }
       });
+    });
+    it('should be a function itself', () => {
+      const data = {
+        prop1: 'value 1',
+        prop2: 'value 2',
+        prop3: 'value 3'
+      };
+      let response = sampleResponse
+        .status(200)
+        .prop('prop1', 'string')
+        .prop('prop2', 'string');
+      
+      expect(response(data)).to.eql(response.getResp()(data));
     });
   });
 });


### PR DESCRIPTION
… new responder

Responses now extend functions (can be invoked), Handlers now accept a new parameter called
responder, handlers validate the returned value

BREAKING CHANGE: The instance level method `name` has been replaced with `alias` on the Response
class